### PR TITLE
Fixes stop/start typo in comments on 0613

### DIFF
--- a/0613.html
+++ b/0613.html
@@ -34,7 +34,7 @@
 	sudo systemctl stop pihole-FTL<br />
 	# delete the FTL database file<br />
 	sudo rm /etc/pihole/pihole-FTL.db<br />
-	# stop pihole FTL service<br />
+	# start pihole FTL service<br />
 	sudo systemctl start pihole-FTL<br />
 	# output reduced pihole db size<br />
 	sudo du /etc/pihole/pihole-FTL.db -h</div>


### PR DESCRIPTION
"stop pihole FTL service" was repeated and 2nd one looks like it should have been "start pihole FTL service"
All the other changes are github normalizing the mixed line endings to Windows-style. I would have chosen *nix line endings is it let me, but I'm sure that would result in even more changes